### PR TITLE
Add BoN voting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ python evaluation/evaluate.py \
     --dataset_split train
 ```
 
+By default the script computed accuracy on the `pred` column. To compute accuracy on a different column, pass `--dataset_col` as follows:
+
+```shell
+python evaluation/evaluate.py \
+    --benchmark math \
+    --dataset_id reliable-agents/Qwen2.5-Math-1.5B-Instruct-bon-completions \
+    --dataset_config reliable-agents_MATH-500--agg_strategy-last--T-1.0--n-256--weighted_bon--agg_strategy-last \
+    --dataset_split train \
+    --dataset_col pred_weighted_bon@1
+```
+
+For Best-of-N, you can evaluate all values of `n` for a given config by running:
+
+```shell
+python evaluation/evaluate_bon.py \
+    --benchmark math \
+    --dataset_id reliable-agents/Qwen2.5-Math-1.5B-Instruct-bon-completions \
+    --dataset_config reliable-agents_MATH-500--agg_strategy-last--T-1.0--n-256--weighted_bon--agg_strategy-last \
+    --dataset_split train \
+    --voting_n 1 2 4 8 16 32 64 128 256
+```
+
+
+## Original README follows
+
 Visit our Hugging Face or ModelScope organization (click the links above). Search checkpoints with names starting with `Qwen2.5-Math-`, and you will find all you need! Enjoy!
 
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To evaluate model outputs first follow the installation examples below and then 
 python evaluation/evaluate.py \
     --benchmark math \
     --dataset_id reliable-agents/Qwen2.5-Math-1.5B-Instruct-bon-completions \
-    --dataset_config lighteval_MATH--agg_strategy-min--T-1.0--n-32 \
+    --dataset_config lighteval_MATH--agg_strategy-min--T-1.0--n-256 \
     --dataset_split train
 ```
 
@@ -36,9 +36,9 @@ By default the script computed accuracy on the `pred` column. To compute accurac
 python evaluation/evaluate.py \
     --benchmark math \
     --dataset_id reliable-agents/Qwen2.5-Math-1.5B-Instruct-bon-completions \
-    --dataset_config reliable-agents_MATH-500--agg_strategy-last--T-1.0--n-256--weighted_bon--agg_strategy-last \
+    --dataset_config reliable-agents_MATH-500--agg_strategy-last--T-1.0--n-256 \
     --dataset_split train \
-    --dataset_col pred_weighted_bon@1
+    --dataset_col pred_weighted@1
 ```
 
 For Best-of-N, you can evaluate all values of `n` for a given config by running:
@@ -47,7 +47,7 @@ For Best-of-N, you can evaluate all values of `n` for a given config by running:
 python evaluation/evaluate_bon.py \
     --benchmark math \
     --dataset_id reliable-agents/Qwen2.5-Math-1.5B-Instruct-bon-completions \
-    --dataset_config reliable-agents_MATH-500--agg_strategy-last--T-1.0--n-256--weighted_bon--agg_strategy-last \
+    --dataset_config reliable-agents_MATH-500--agg_strategy-last--T-1.0--n-256 \
     --dataset_split train \
     --voting_n 1 2 4 8 16 32 64 128 256
 ```

--- a/evaluation/evaluate_bon.py
+++ b/evaluation/evaluate_bon.py
@@ -1,0 +1,91 @@
+import argparse
+import numpy as np
+from tqdm import tqdm
+from pebble import ProcessPool
+from concurrent.futures import TimeoutError
+from datasets import load_dataset
+from tqdm.auto import tqdm
+import pandas as pd
+from datasets import Dataset
+
+from grader import *
+
+from parser import *
+from utils import load_jsonl
+from python_executor import PythonExecutor
+
+def evaluate(benchmark: str, dataset_id: str, dataset_config: str = None, dataset_split: str = "test", dataset_col: str = "pred", samples: list=None, max_num_samples=None):
+    samples = load_dataset(dataset_id, name=dataset_config, split=dataset_split)
+    if "idx" not in samples.column_names:
+        samples = samples.map(lambda x, idx: {"idx": idx}, with_indices=True)
+        
+    if max_num_samples:
+        print(f"max_num_samples: {max_num_samples} / {len(samples)}")
+        samples = samples[:max_num_samples]
+
+
+    def parse_gt(x):
+        x['gt_cot'], x['gt'] = parse_ground_truth(x, benchmark)
+        return x
+    samples = samples.map(parse_gt, desc="Parsing ground truth", num_proc=12, load_from_cache_file=False)
+    samples = samples.map(extract_answer_map, fn_kwargs={"data_name": benchmark, "col": dataset_col}, desc="Parsing predictions", num_proc=12, load_from_cache_file=False)
+    params = [(idx, pred, gt) for idx, pred, gt in zip(samples['idx'], samples['pred'], samples['gt'])]
+
+    scores = []
+    timeout_cnt = 0 
+
+    with ProcessPool(max_workers=8) as pool:
+        future = pool.map(math_equal_process, params, timeout=3)
+        iterator = future.result()
+        with tqdm(total=len(samples), desc="Evaluate") as progress_bar:
+            while True:
+                try:
+                    result = next(iterator)
+                    scores.append(result)
+                except StopIteration:
+                    break
+                except TimeoutError as error:
+                    print(error)
+                    scores.append(False)
+                    timeout_cnt += 1
+                except Exception as error:
+                    print(error.traceback)
+                    exit()
+                progress_bar.update(1) 
+
+    mean_score = np.mean(scores) * 100
+
+    result_json = {
+        "num_samples": len(samples),
+        "num_scores": len(scores),
+        "timeout_samples": timeout_cnt,
+        "acc": mean_score
+    }
+
+    print(result_json)
+    return samples, result_json
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--benchmark", type=str, default="math")
+    parser.add_argument("--dataset_id", type=str, required=True)
+    parser.add_argument("--dataset_config", type=str, default=None)
+    parser.add_argument("--dataset_split", type=str, default="test")
+    parser.add_argument("--max_num_samples", type=int, default=None)
+    parser.add_argument("--voting_n", type=int, nargs='+', required=True)
+    args = parser.parse_args()
+    return args
+
+if __name__ == "__main__":
+    args = parse_args()
+    data = {"n": [], "acc_naive": [], "acc_weighted": [], "acc_maj": []}
+    for n in tqdm(args.voting_n, desc=f"Applying voting..."):
+        data["n"].append(n)
+        for agg in ["naive", "weighted", "maj"]:
+            _, scores = evaluate(benchmark=args.benchmark, dataset_id=args.dataset_id, dataset_config=args.dataset_config, dataset_split=args.dataset_split, dataset_col=f"pred_{agg}@{n}",
+                    max_num_samples=args.max_num_samples)
+            data[f"acc_{agg}"].append(scores["acc"])
+
+    ds = Dataset.from_dict(data)
+    url = ds.push_to_hub(args.dataset_id, config_name=f"{args.dataset_config}--evals")
+    print(f"Results saved to {url}")


### PR DESCRIPTION
This PR automates the evaluation of BoN completions by iterating over a set of `n` values and automatically running the `naive` and `weighted` and `maj` scores.

The result is a new dataset config called `{config}-evals` that can be viewed in the viewer

Example: https://huggingface.co/datasets/reliable-agents/Qwen2.5-Math-1.5B-Instruct-bon-prm-completions/viewer/reliable-agents_MATH-500--agg_strategy-last--T-1.0--n-256--evals